### PR TITLE
Rails 5 deprecations

### DIFF
--- a/lib/sentient_user.rb
+++ b/lib/sentient_user.rb
@@ -39,7 +39,7 @@ end
 module SentientController
   def self.included(base)
     base.class_eval {
-      before_filter do |c|
+      before_action do |c|
         User.current = c.send(:current_user)
       end
     }


### PR DESCRIPTION
changing before_filter to before_action since before_filter is getting removed in rails 5.1
